### PR TITLE
라이브러리 관련 세팅 작업

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2023 off-design-system
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS," WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # OFF_Design_System
+
+## Getting Started
+
+```bash
+npm install off-design-system
+yarn add off-design-system
+```
+
+프로젝트 루트에 `index.css` 파일을 추가해주세요.
+
+```tsx
+import "serif-ui-components/dist/index.css";
+```
+
+```tsx
+import { Button } from "off-design-system";
+
+const App = () => {
+  return (
+    <div>
+      <Button buttonType="outline" label="Serif test" />
+    </div>
+  );
+};
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "off-design-system",
-  "version": "0.0.0",
+  "version": "0.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "off-design-system",
-      "version": "0.0.0",
+      "version": "0.0.20",
+      "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,23 @@
 {
   "name": "off-design-system",
+  "description": "오프 디자인 시스템",
+  "homepage": "https://github.com/prgrms-web-devcourse/OFF_Design_System",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prgrms-web-devcourse/OFF_Design_System.git"
+  },
   "private": false,
-  "version": "0.0.18",
+  "version": "0.0.20",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build && npm run tailwind",
+    "tailwind": "npx tailwindcss -o ./dist/index.css --minify",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
+    "release": "sh ./scripts/release.sh"
+  },
   "type": "module",
   "main": "dist/index.es.js",
   "types": "dist/index.d.ts",
@@ -20,15 +36,38 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc && vite build && npm run tailwind",
-    "tailwind": "npx tailwindcss -o ./dist/index.css --minify",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview",
-    "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
-  },
+  "keywords": [
+    "react",
+    "typescript",
+    "tailwindcss",
+    "ui",
+    "components",
+    "storybook",
+    "vite"
+  ],
+  "contributors": [
+    {
+      "name": "Jonggil Lee",
+      "email": "dbdltm22@naver.com",
+      "url": "https://github.com/jgjgill"
+    },
+    {
+      "name": "Beomjin Lee",
+      "email": "maplestory1419@naver.com",
+      "url": "https://github.com/euan-lee"
+    },
+    {
+      "name": "Jonghyun Lee",
+      "email": "whdgus7578@naver.com",
+      "url": "https://github.com/jonghyunlee95"
+    },
+    {
+      "name": "Jiseon Lim",
+      "email": "dpf226@naver.com",
+      "url": "https://github.com/Lim-JiSeon"
+    }
+  ],
+  "license": "MIT",
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/prgrms-web-devcourse/OFF_Design_System.git"
   },
   "private": false,
-  "version": "0.0.20",
+  "version": "0.0.22",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build && npm run tailwind",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,22 @@
+  #!/bin/bash
+
+  # Read the current package.json version
+  current_version=$(node -p "require('./package.json').version")
+  echo "Current version: $current_version"
+
+  # Increment the version number
+  new_version=$(npm version --no-git-tag-version patch)
+  echo "New version: $new_version"
+
+  # Build the project
+  $(npm run build)
+
+  # Publish the project
+  $(npm publish --access public)
+
+  # Commit the changes
+  git add .
+  git commit -m "RELEASE (serif) : new release $new_version"
+
+  # Inform the user
+  echo "Released $new_version"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,7 +16,7 @@
 
   # Commit the changes
   git add .
-  git commit -m "RELEASE (serif) : new release $new_version"
+  git commit -m "release: new release $new_version"
 
   # Inform the user
   echo "Released $new_version"


### PR DESCRIPTION
## 구현 내용

라이브러리에서 사용되는 기본 세팅 작업을 진행했습니다.

아마도 이제 `npm publish`를 해도 에러가 뜨지 않을 것 같습니다.
이때 배포되는 버전은 기존 버전보다 높아야 하는 것을 주의해주세요..!

배포와 관련해서 깃허브에서 `release`와 `tag`라는 것을 활용할 수 있는 것 같습니다..!
우선 저도 공부중인 부분이어서 한 번 살펴보시면 좋을 것 같네요!!

[release](https://github.com/prgrms-web-devcourse/OFF_Design_System/releases)

<!-- ## 스크린샷 -->

npm 페이지에서 기본적인 내용들을 추가했습니다.

<img width="1046" alt="스크린샷 2023-10-05 오후 3 22 55" src="https://github.com/prgrms-web-devcourse/OFF_Design_System/assets/79239852/0340bfe2-3a3d-4da0-b586-7de8921aaffe">

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

배포 관련 스크립트가 하나 추가되었습니다.
스크립트 폴더에 `release.sh` 파일입니다.
`script`에 `"release": "sh ./scripts/release.sh"`를 추가했습니다.

하는 역할은  `npm run release`를 할 시 배포 버전이 한 단계 올리는 커밋이 발생합니다.

ex) 버전: 0.0.20 => 0.0.21, 커밋 메시지: release: new release 0.0.21

## 궁금한 점

## 이슈 번호

- close #10 

<!--## 테스트 계획 또는 완료 사항-->
