### PR TITLE
:tada: 이미지 업로더 컴포넌트 구현

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
 export { default as JGButton } from "./src/components/buttons/JGButton";
+export { default as ImageUploader } from "./src/components/uploads/ImageUploader";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "off-design-system",
-  "version": "0.0.20",
+  "version": "0.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "off-design-system",
-      "version": "0.0.20",
+      "version": "0.0.23",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "off-design-system",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "off-design-system",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "off-design-system",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "off-design-system",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "off-design-system",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "off-design-system",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/prgrms-web-devcourse/OFF_Design_System.git"
   },
   "private": false,
-  "version": "0.0.25",
+  "version": "0.0.26",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build && npm run tailwind",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
       "url": "https://github.com/jonghyunlee95"
     },
     {
-      "name": "limjiseon",
+      "name": "Jiseon Lim",
       "email": "dpf226@naver.com",
       "url": "https://github.com/Lim-JiSeon"
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/prgrms-web-devcourse/OFF_Design_System.git"
   },
   "private": false,
-  "version": "0.0.22",
+  "version": "0.0.23",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build && npm run tailwind",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/prgrms-web-devcourse/OFF_Design_System.git"
   },
   "private": false,
-  "version": "0.0.23",
+  "version": "0.0.24",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build && npm run tailwind",
@@ -62,7 +62,7 @@
       "url": "https://github.com/jonghyunlee95"
     },
     {
-      "name": "Jiseon Lim",
+      "name": "limjiseon",
       "email": "dpf226@naver.com",
       "url": "https://github.com/Lim-JiSeon"
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/prgrms-web-devcourse/OFF_Design_System.git"
   },
   "private": false,
-  "version": "0.0.24",
+  "version": "0.0.25",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build && npm run tailwind",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,13 @@
 import JGButton from "./components/buttons/JGButton";
+import ImageUploader from "./components/uploads/ImageUploader";
 
 function App() {
-  return <JGButton>jgjgill</JGButton>;
+  return (
+    <>
+      <JGButton>jgjgill</JGButton>
+      <ImageUploader></ImageUploader>
+    </>
+  );
 }
 
 export default App;

--- a/src/components/uploads/ImageUploader.tsx
+++ b/src/components/uploads/ImageUploader.tsx
@@ -1,0 +1,71 @@
+import React, { useState, useRef } from "react";
+
+export const defaultImg =
+  "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR2Riw8iKZ4n4XAI3zEc0ShoGo1S5Z-oQdRWw&usqp=CAU";
+
+type ImageUploaderPropsType = {
+  buttonImg?: string;
+  onChange?: (_files: FileList | null) => void;
+  shape?: "rounded" | "circle" | "square";
+  size?: number;
+};
+
+const ImageUploader = ({
+  buttonImg = defaultImg,
+  onChange,
+  shape = "rounded",
+  size = 200,
+}: ImageUploaderPropsType) => {
+  const [image, setImage] = useState(buttonImg);
+  const fileInput = useRef<HTMLInputElement | null>(null);
+
+  const uploadHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const target = e.target as HTMLInputElement;
+    const file = target.files![0];
+    if (file) {
+      if (onChange) onChange(target.files);
+      setImage(file.toString());
+      previewImage(file);
+    } else {
+      setImage(defaultImg);
+      previewImage(null);
+    }
+  };
+
+  const previewImage = (file: Blob | null) => {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => {
+      if (reader.readyState === 2 && typeof reader.result === "string")
+        setImage(reader.result);
+    };
+  };
+
+  return (
+    <>
+      <input
+        type="file"
+        style={{ display: "none" }}
+        accept="image/jpg, image/png, image/jpeg"
+        name="img_uploader"
+        onChange={uploadHandler}
+        ref={fileInput}
+      />
+      <img
+        className={`${
+          shape === "rounded"
+            ? "rounded-lg"
+            : shape === "circle"
+            ? "rounded-full"
+            : ""
+        }`}
+        style={{ width: `${size}px`, height: `${size}px` }}
+        src={image}
+        onClick={() => fileInput.current?.click()}
+      />
+    </>
+  );
+};
+
+export default ImageUploader;

--- a/src/components/uploads/ImageUploader.tsx
+++ b/src/components/uploads/ImageUploader.tsx
@@ -44,8 +44,9 @@ const ImageUploader = ({
     const reader = new FileReader();
     reader.readAsDataURL(file);
     reader.onload = () => {
-      if (reader.readyState === 2 && typeof reader.result === "string")
+      if (reader.readyState === 2 && typeof reader.result === "string") {
         setImage(reader.result);
+      }
     };
   };
 

--- a/src/components/uploads/ImageUploader.tsx
+++ b/src/components/uploads/ImageUploader.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from "react";
 
-export const defaultImg =
+export const DEFAULT_IMAGE =
   "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR2Riw8iKZ4n4XAI3zEc0ShoGo1S5Z-oQdRWw&usqp=CAU";
 
 type ImageUploaderPropsType = {
@@ -11,23 +11,30 @@ type ImageUploaderPropsType = {
 };
 
 const ImageUploader = ({
-  buttonImg = defaultImg,
+  buttonImg = DEFAULT_IMAGE,
   onChange,
   shape = "rounded",
   size = 200,
 }: ImageUploaderPropsType) => {
   const [image, setImage] = useState(buttonImg);
-  const fileInput = useRef<HTMLInputElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const shapeConfig = {
+    rounded: "rounded-lg",
+    circle: "rounded-full",
+    square: "rounded-none",
+  };
 
   const uploadHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.target as HTMLInputElement;
     const file = target.files![0];
     if (file) {
       if (onChange) onChange(target.files);
+
       setImage(file.toString());
       previewImage(file);
     } else {
-      setImage(defaultImg);
+      setImage(image);
       previewImage(null);
     }
   };
@@ -50,19 +57,13 @@ const ImageUploader = ({
         accept="image/jpg, image/png, image/jpeg"
         name="img_uploader"
         onChange={uploadHandler}
-        ref={fileInput}
+        ref={fileInputRef}
       />
       <img
-        className={`${
-          shape === "rounded"
-            ? "rounded-lg"
-            : shape === "circle"
-            ? "rounded-full"
-            : ""
-        }`}
+        className={`${shapeConfig[shape]}`}
         style={{ width: `${size}px`, height: `${size}px` }}
         src={image}
-        onClick={() => fileInput.current?.click()}
+        onClick={() => fileInputRef.current?.click()}
       />
     </>
   );


### PR DESCRIPTION
## 구현 내용
- 파일 불러오기 전에 화면상에 보이는 버튼 이미지를 설정할 수 있습니다. (buttonImg)
- 파일을 불러온 뒤 불러온 파일을 처리하는 함수를 설정할 수 있습니다. (onChange)
- 불러온 파일을 미리보기 shape을 설정할 수 있습니다. (shape)
- 불러온 파일을 미리보기 size를 설정할 수 있습니다. (size)

<!-- ## 스크린샷 -->
파일 불러오기 전
<img width="155" alt="image" src="https://github.com/prgrms-web-devcourse/OFF_Design_System/assets/83554018/4c28ca6e-f172-45f7-8723-d01ddec5b57a">

파일 불러온 후 - rounded
<img width="164" alt="image" src="https://github.com/prgrms-web-devcourse/OFF_Design_System/assets/83554018/1c0533ea-fc2a-4921-b2c4-3ba7e869d406">

파일 불러온 후 - circle
<img width="163" alt="image" src="https://github.com/prgrms-web-devcourse/OFF_Design_System/assets/83554018/68000782-bbcc-4dc3-b36f-8eed4b7c9d08">

파일 불러온 후 - square
<img width="158" alt="image" src="https://github.com/prgrms-web-devcourse/OFF_Design_System/assets/83554018/f0ec15d2-dce1-4ff2-9348-f2a158c9137e">


## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->
- 해당 props들은 모두 optional 입니다.
- buttonImg는 기본적으로 아래 사진처럼 설정되어 있습니다.
- onChange는 없을 경우 따로 동작하는 기능이 없습니다.
- shape은 기본적으로 rounded 입니다.
- size는 기본적으로 200px 입니다.

사용방법
```ts
<ImageUploader></ImageUploader>

<ImageUploader size=100></ImageUploader>

<ImageUploader shape="circle"></ImageUploader>

<ImageUploader onChange={() => console.log("이미지를 업로드했습니다.")}></ImageUploader>
```


## 궁금한 점
- 현재 이미지를 가져온 뒤 한 번 더 클릭하면 또 이미지를 가져오고 그 이미지로 미리보기가 바뀌게끔 설정했습니다.(이미지 1개로 고정)
- 별도의 가져온 이미지를 취소하는 버튼을 붙일까 고민했는데 우선 작업하지는 않았습니다. 
- 추후 좀 더 고민해 본 뒤 어떻게 하면 좋을 지 정해 코드를 수정하겠습니다.
- 즉 현재 상태는 이미지를 가져오면 그 이미지를 다시 클릭했을 때 다른 이미지를 가져올 수 있게 설정되어 있습니다. 

## 이슈 번호

- close #12 

<!--## 테스트 계획 또는 완료 사항-->
